### PR TITLE
Set default device for StarCoder to `cuda`

### DIFF
--- a/generators.py
+++ b/generators.py
@@ -12,7 +12,7 @@ class GeneratorBase:
 
 
 class StarCoder(GeneratorBase):
-    def __init__(self, pretrained: str, device: str = None, device_map: str = None):
+    def __init__(self, pretrained: str, device: str = 'cuda', device_map: str = None):
         self.pretrained: str = pretrained
         self.pipe: Pipeline = pipeline(
             "text-generation", model=pretrained, torch_dtype=torch.bfloat16, device=device, device_map=device_map)


### PR DESCRIPTION
SantaCoder and ReplitCode already have this set, so I figured StarCoder should as well.